### PR TITLE
Stop new comments overwriting existing ones

### DIFF
--- a/components/Comments.js
+++ b/components/Comments.js
@@ -10,7 +10,9 @@ export default function Comments({initialComments = []}) {
   const [comments, setComments] = useState(initialComments);
 
    const [channel] = useChannel("comment-channel", (message) => {
-     setComments([...comments, message.data])
+     setComments((comments) => {
+      return [...comments, message.data];
+    });
    });
 
   const submitComment = async (username, comment, clearForm) => {


### PR DESCRIPTION
Currently, adding a new comment overwrites the last one in the UI. Modified `setState()` in `Comments.js` to prevent this.